### PR TITLE
Default expires_in value is broken

### DIFF
--- a/lib/redis_dedupe.rb
+++ b/lib/redis_dedupe.rb
@@ -10,7 +10,7 @@ module RedisDedupe
 
     attr_reader :key, :expires_in
 
-    def initialize(redis, key, expires_in = Time.now + SEVEN_DAYS)
+    def initialize(redis, key, expires_in = SEVEN_DAYS)
       @redis      = redis
       @key        = key
       @expires_in = expires_in

--- a/spec/redis_dedupe_spec.rb
+++ b/spec/redis_dedupe_spec.rb
@@ -10,12 +10,12 @@ describe RedisDedupe::Set do
 
   it "defaults expires_in to 7 days" do
     dedupe = RedisDedupe::Set.new(:redis, :key)
-    expect(dedupe.expires_in.to_i).to eq((Time.now + (7*24*60*60)).to_i)
+    expect(dedupe.expires_in.to_i).to eq(7 * 24 * 60 * 60)
   end
 
-  it "optionally receives an expires_in time" do
-    dedupe = RedisDedupe::Set.new(:redis, :key, (Time.now + (7*24*60)).to_i)
-    expect(dedupe.expires_in.to_i).to eq((Time.now + (7*24*60)).to_i)
+  it "optionally receives an expires_in seconds value" do
+    dedupe = RedisDedupe::Set.new(:redis, :key, 60)
+    expect(dedupe.expires_in.to_i).to eq(60)
   end
 end
 


### PR DESCRIPTION
The default expiration value is a Time object, not integer seconds.  The expire command for redis needs integer seconds, not a time object, so this doesn't work.

the reasons we haven't noticed this are:
- MockRedis doesn't blow up if given a time instance rather than an integer
- The pipelined command (I think) is absorbing the error, so the command runs, doesn't work, but doesn't throw an exception.

What this bug prevents are non-finished dedupes from being expired by a ttl, because right now their ttl is not actually set.  It doesn't prevent the deduping itself for working.
