### PR TITLE
Adding catalog-info document for Radiator

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
     - redis
     - dedupe
   annotations:
-    backstage.io/source-location: url:https://github.com/Kajabi/redis_dedupe/tree/main
+    backstage.io/source-location: url:https://github.com/Kajabi/redis_dedupe/tree/master
     github.com/project-slug: Kajabi/redis_dedupe
 spec:
   system: kajabi-products

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: redis-dedupe
+  description: |
+    This is a weak deduper to make things like bulk email run safer. It is not a lock safe for financial/security needs because it uses a weak redis locking pattern that can have race conditions. However, imagine a bulk email job that loops over 100 users, and enqueues a background email for each user. If the job fails at iteration 50, a retry would enqueue all the users again and many will receive dupes. This would continue multiple times as the parent job continued to rerun. By marking that a subjob has been enqueued, we can let that isolated job handle its own failures, and the batch enqueue job can run multiple times without re-enqueueing the same subjobs.
+  tags:
+    - gem
+    - ruby
+    - rails
+    - redis
+    - dedupe
+  annotations:
+    backstage.io/source-location: url:https://github.com/Kajabi/redis_dedupe/tree/main
+    github.com/project-slug: Kajabi/redis_dedupe
+spec:
+  system: kajabi-products
+  type: gem
+  owner: standard-model
+  lifecycle: production


### PR DESCRIPTION
This adds a catalog-info.yaml document to register the repo with the Radiator project. At this time we have set the owner as `standard-model`, but I'm reviewing with the contributors to ensure that's accurate.