### PR TITLE
Update pipelined to use block argument in prep for redis 5

### DIFF
--- a/lib/redis_dedupe.rb
+++ b/lib/redis_dedupe.rb
@@ -17,9 +17,9 @@ module RedisDedupe
     end
 
     def check(member)
-      results = redis.pipelined do
-        redis.sadd(key, member)
-        redis.expire(key, expires_in)
+      results = redis.pipelined do |pipeline|
+        pipeline.sadd(key, member)
+        pipeline.expire(key, expires_in)
       end
 
       if results[0]

--- a/lib/redis_dedupe/version.rb
+++ b/lib/redis_dedupe/version.rb
@@ -1,3 +1,3 @@
 module RedisDedupe
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Use of this gem is causing the following deprecation warning:

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
redis.pipelined do
  redis.get("key")
end
should be replaced by
redis.pipelined do |pipeline|
  pipeline.get("key")
end
```