### PR TITLE
Update to using the `sadd?` method to avoid deprecation message

### DIFF
--- a/lib/redis_dedupe.rb
+++ b/lib/redis_dedupe.rb
@@ -18,7 +18,7 @@ module RedisDedupe
 
     def check(member)
       results = redis.pipelined do |pipeline|
-        pipeline.sadd(key, member)
+        pipeline.sadd?(key, member)
         pipeline.expire(key, expires_in)
       end
 

--- a/lib/redis_dedupe/version.rb
+++ b/lib/redis_dedupe/version.rb
@@ -1,3 +1,3 @@
 module RedisDedupe
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
Prevents [this deprecation message](https://github.com/redis/redis-rb/blob/v4.8.1/lib/redis/commands/sets.rb#L24-L26) from occurring when calling the `check` method.

In this location we aren't concerned with the returned integer.