### PR TITLE
feat(helpers): allow optionally overriding set expires_in

### DIFF
--- a/lib/redis_dedupe.rb
+++ b/lib/redis_dedupe.rb
@@ -7,12 +7,13 @@ module RedisDedupe
 
   class Set
     SEVEN_DAYS = 7 * 24 * 60 * 60
+    DEFAULT_EXPIRES_IN = SEVEN_DAYS
 
     attr_reader :key, :expires_in
 
-    def initialize(redis, key, expires_in = SEVEN_DAYS)
-      @redis      = redis
-      @key        = key
+    def initialize(redis, key, expires_in = DEFAULT_EXPIRES_IN)
+      @redis = redis
+      @key = key
       @expires_in = expires_in
     end
 
@@ -42,7 +43,12 @@ module RedisDedupe
     private
 
     def dedupe
-      @dedupe ||= RedisDedupe::Set.new(RedisDedupe.client, [dedupe_namespace, dedupe_id].join(':'))
+      @dedupe ||=
+        RedisDedupe::Set.new(
+          RedisDedupe.client,
+          [dedupe_namespace, dedupe_id].join(':'),
+          dedupe_expires_in,
+        )
     end
 
     # Implement in class, should return an integer or string:
@@ -55,6 +61,19 @@ module RedisDedupe
     #
     def dedupe_id
       raise NotImplementedError
+    end
+
+    # Override in class if needed, should return an integer representing the
+    # number of seconds until expiry.
+    #
+    # Ex.
+    #
+    #   def dedupe_expires in
+    #     24 * 60 * 60 # => Or can use e.g. `1.day` in Rails.
+    #   end
+    #
+    def dedupe_expires_in
+      RedisDedupe::Set::DEFAULT_EXPIRES_IN
     end
 
     def dedupe_namespace

--- a/lib/redis_dedupe/version.rb
+++ b/lib/redis_dedupe/version.rb
@@ -1,3 +1,3 @@
 module RedisDedupe
-  VERSION = "0.0.6"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
There are times, when using the mixed-in Helpers, that you don't want the default SEVEN_DAYS dedup expiration.

This update the helpers to add a hook method, dedupe_expires_in, that can be overridden to use a custom expires_in value. It defaults to the SEVEN_DAYS default just as before so is backwards compatible.